### PR TITLE
fix: JS type mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 See the [Roadmap](https://github.com/vista-art/fragmentcolor/blob/main/ROADMAP.md) for planned features.
 
+## 0.10.9 Bugfix: Stable kind branding for JS (avoids mangling in minified builds)
+
+### Bugfixes
+
+- Stable kind branding for JS/Python (avoids mangling in minified builds)
+  - `crate::impl_fc_kind!(TypeName, "TypeName");` in each type's file
+  - `pub mod fc_kind;` and `pub use fc_kind::FcKind;` in lib.rs
+
 ## 0.10.8 Concurrency‑safe uniforms, typed errors, and web gallery
 
 ### API changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "fragmentcolor"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "bytemuck",
  "cfg_aliases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fragmentcolor"
-version = "0.10.8"
+version = "0.10.9"
 homepage = "https://fragmentcolor.org"
 repository = "https://github.com/vista-art/fragmentcolor"
 description = "Easy GPU Rendering for Javascript, Python, Swift and Kotlin"

--- a/build_web
+++ b/build_web
@@ -15,32 +15,6 @@ SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # Build WASM package
 wasm-pack build --target web $WASM_PACK_CONFIGURATION --out-dir "$SOURCE_DIR/platforms/web/pkg"
 
-# Inject stable brand properties on exported class prototypes for robust type checks
-PKG_JS="$SOURCE_DIR/platforms/web/pkg/fragmentcolor.js"
-API_OBJECTS_FILE="$SOURCE_DIR/generated/api_objects.txt"
-if [ -f "$PKG_JS" ]; then
-  {
-    cat <<'EOF'
-(function(){
-  function brand(ctor, name){
-    try{
-      if (typeof ctor === 'function' && ctor.prototype) {
-        Object.defineProperty(ctor.prototype, "__fc_kind", { value: name, configurable: false, enumerable: false, writable: false });
-      }
-    } catch {}
-  }
-EOF
-    if [ -f "$API_OBJECTS_FILE" ]; then
-      while IFS= read -r NAME; do
-        # skip empty lines
-        if [ -z "$NAME" ]; then continue; fi
-        # Emit a guarded brand call; unknown identifiers will throw and be caught
-        printf "  try{ brand(%s, \"%s\"); }catch{}\n" "$NAME" "$NAME"
-      done < "$API_OBJECTS_FILE"
-    fi
-    echo "})();"
-  } >> "$PKG_JS"
-fi
 
 # Ensure npm package has a language-specific README
 if [ -f "$SOURCE_DIR/README_JS.md" ]; then

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fragmentcolor-website",
   "type": "module",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "packageManager": "pnpm@10.15.1",
   "scripts": {
     "dev": "astro dev",

--- a/docs/website/src/components/VersionBadge.astro
+++ b/docs/website/src/components/VersionBadge.astro
@@ -1,7 +1,7 @@
 ---
 // This value is updated by build.rs during the Rust build.
 // Keep this exact line format so the build script can replace it reliably.
-const VERSION = '0.10.8';
+const VERSION = '0.10.9';
 const RELEASES = 'https://github.com/vista-art/fragmentcolor/releases';
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ features = ["python", "pyo3/extension-module"]
 
 [project]
 name = "fragmentcolor"
-version = "0.10.8"
+version = "0.10.9"
 description = "Easy cross-platform GPU Rendering for Javascript, Python, Swift and Kotlin"
 readme = "README_PY.md"
 requires-python = ">=3.9"

--- a/src/fc_kind.rs
+++ b/src/fc_kind.rs
@@ -1,8 +1,8 @@
 //! Cross-language stable kind branding.
 //!
 //! Provides a trait and a helper macro to expose a stable "__fc_kind"
-//! property in JavaScript (via wasm-bindgen) and Python (via pyo3), so
-//! type identity checks remain reliable under bundler/minifier mangling.
+//! property in JavaScript (via wasm-bindgen), so type identity checks
+//! remain stable under bundler/minifier mangling.
 
 /// Marker trait that supplies a stable, compile-time kind string.
 pub trait FcKind {

--- a/src/fc_kind.rs
+++ b/src/fc_kind.rs
@@ -1,0 +1,34 @@
+//! Cross-language stable kind branding.
+//!
+//! Provides a trait and a helper macro to expose a stable "__fc_kind"
+//! property in JavaScript (via wasm-bindgen) and Python (via pyo3), so
+//! type identity checks remain reliable under bundler/minifier mangling.
+
+/// Marker trait that supplies a stable, compile-time kind string.
+pub trait FcKind {
+    const KIND: &'static str;
+}
+
+/// Implement FcKind for a type and expose a platform getter/property.
+///
+/// Usage:
+///   impl_fc_kind!(Renderer, "Renderer");
+///   impl_fc_kind!(CanvasTarget, "CanvasTarget");
+#[macro_export]
+macro_rules! impl_fc_kind {
+    ($ty:ty, $name:literal) => {
+        impl $crate::FcKind for $ty {
+            const KIND: &'static str = $name;
+        }
+
+        // JavaScript: expose a non-configurable prototype getter named "__fc_kind".
+        #[cfg(wasm)]
+        #[wasm_bindgen]
+        impl $ty {
+            #[wasm_bindgen(getter, js_name = "__fc_kind")]
+            pub fn js_fc_kind(&self) -> String {
+                <Self as $crate::FcKind>::KIND.into()
+            }
+        }
+    };
+}

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -23,6 +23,8 @@ pub struct Frame {
     dependencies: Vec<(usize, usize)>,
 }
 
+crate::impl_fc_kind!(Frame, "Frame");
+
 impl Frame {
     #[lsp_doc("docs/api/core/frame/new.md")]
     pub fn new() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,10 @@ mod macros;
 /// Top-level platform-specific initializers
 mod platforms;
 
+/// Stable kind branding across language bindings
+pub mod fc_kind;
+
 pub use {
-    color::*, error::*, frame::*, mesh::*, pass::*, region::*, renderer::*, shader::*, size::*,
-    target::*, texture::*,
+    color::*, error::*, fc_kind::*, frame::*, mesh::*, pass::*, region::*, renderer::*, shader::*,
+    size::*, target::*, texture::*,
 };

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -38,6 +38,8 @@ pub struct Mesh {
     pub(crate) pass: Arc<crate::pass::PassObject>,
 }
 
+crate::impl_fc_kind!(Mesh, "Mesh");
+
 impl Default for Mesh {
     fn default() -> Self {
         Self::new()

--- a/src/pass/mod.rs
+++ b/src/pass/mod.rs
@@ -66,6 +66,8 @@ pub struct Pass {
     pub(crate) object: Arc<PassObject>,
 }
 
+crate::impl_fc_kind!(Pass, "Pass");
+
 impl Pass {
     #[lsp_doc("docs/api/core/pass/new.md")]
     pub fn new(name: &str) -> Self {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -78,6 +78,8 @@ pub struct Renderer {
     context: RwLock<Option<Arc<RenderContext>>>,
 }
 
+crate::impl_fc_kind!(Renderer, "Renderer");
+
 impl Renderer {
     #[lsp_doc("docs/api/core/renderer/new.md")]
     pub fn new() -> Self {

--- a/src/shader/mod.rs
+++ b/src/shader/mod.rs
@@ -40,6 +40,8 @@ pub struct Shader {
     pub(crate) object: Arc<ShaderObject>,
 }
 
+crate::impl_fc_kind!(Shader, "Shader");
+
 impl Default for Shader {
     fn default() -> Self {
         Self::new(DEFAULT_SHADER).expect("SAFETY: DEFAULT_SHADER is built-in")

--- a/src/target/platform/web.rs
+++ b/src/target/platform/web.rs
@@ -13,6 +13,8 @@ pub struct CanvasTarget {
     inner: Arc<Mutex<WindowTarget>>,
 }
 
+crate::impl_fc_kind!(CanvasTarget, "CanvasTarget");
+
 impl CanvasTarget {
     pub(crate) fn new(
         context: Arc<RenderContext>,

--- a/src/target/texture.rs
+++ b/src/target/texture.rs
@@ -14,6 +14,8 @@ pub struct TextureTarget {
     pub(crate) id: Arc<parking_lot::RwLock<Option<crate::texture::TextureId>>>,
 }
 
+crate::impl_fc_kind!(TextureTarget, "TextureTarget");
+
 impl TextureTarget {
     pub(crate) fn new(
         context: Arc<RenderContext>,

--- a/src/texture/mod.rs
+++ b/src/texture/mod.rs
@@ -219,6 +219,8 @@ pub struct Texture {
     pub(crate) id: TextureId,
 }
 
+crate::impl_fc_kind!(Texture, "Texture");
+
 impl Texture {
     /// Creates a new Texture from a RenderContext.
     pub(crate) fn new(


### PR DESCRIPTION
## 0.10.9 Bugfix: Stable kind branding for JS (avoids mangling in minified builds)

### Bugfixes

- Stable kind branding for JS (avoids mangling in minified builds)
  - `crate::impl_fc_kind!(TypeName, "TypeName");` in each type's file
  - `pub mod fc_kind;` and `pub use fc_kind::FcKind;` in lib.rs