### PR TITLE
docs(tutorials): draft Hello Triangle while we iterate

### DIFF
--- a/docs/website/src/content/docs/tutorials/01-hello-triangle.mdx
+++ b/docs/website/src/content/docs/tutorials/01-hello-triangle.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hello, 1000 triangles
 description: Three ways to draw a triangle with FragmentColor — from a one-shot URL to a few thousand animated copies.
+draft: true
 ---
 
 import Snippet from "../../../components/Snippet.astro";


### PR DESCRIPTION
## Summary
- Adds `draft: true` to `docs/website/src/content/docs/tutorials/01-hello-triangle.mdx` so Starlight excludes the page from production builds and the autogenerated sidebar.
- Local iteration continues: American English pass, fluid newcomer-friendly prose, runnable shaders, and an ergonomic Repl that pairs host code with shader code (single component with tabs, or stacked — TBD).

## Test plan
- [ ] CI green
- [ ] After merge, https://fragmentcolor.org/tutorials/01-hello-triangle/ no longer renders and the Tutorials sidebar drops the entry
- [ ] In local \`astro dev\`, the page is still visible for editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)